### PR TITLE
Parse body size

### DIFF
--- a/configs/simplem.conf
+++ b/configs/simplem.conf
@@ -4,6 +4,8 @@ server {
 	root ./var;
 	index index.html;
 
+	client_max_body_size 1G;
+
 	error_page 401 /error/401.html;
 	error_page 412 /index.html;
 	error_page 404 /img/confused_man_laptop.jpg;
@@ -64,7 +66,7 @@ server {
 	root ./www;
 	index index.html;
 
-	client_max_body_size 123456789m;
+	client_max_body_size 1024m;
 
 	location /www {
 		root ./var/www/;

--- a/configs/simplem.conf
+++ b/configs/simplem.conf
@@ -64,6 +64,8 @@ server {
 	root ./www;
 	index index.html;
 
+	client_max_body_size 123456789m;
+
 	location /www {
 		root ./var/www/;
 	}

--- a/include/ParseServerBlock.hpp
+++ b/include/ParseServerBlock.hpp
@@ -12,7 +12,7 @@ class pServerBlock {
 		int _port;
 		map<int, string> _error_pages;
 		vector<string> _server_names;
-		string _client_max_body_size;
+		unsigned int _client_max_body_size;
 		string _root;
 		string _index;
 		vector<Location> _locations;
@@ -23,7 +23,7 @@ class pServerBlock {
 			int port,
 			string root,
 			string index,
-			string client_max_body_size,
+			unsigned int client_max_body_size,
 			vector<string> server_names,
 			map<int, string> error_pages,
 			vector<Location> locations);
@@ -32,7 +32,7 @@ class pServerBlock {
 		string get_host() const;
 		int get_port() const;
 		vector<string> get_server_names() const;
-		string get_client_max_body_size() const;
+		unsigned int get_client_max_body_size() const;
 		string get_root() const;
 		string get_index() const;
 		vector<Location> get_locations() const;
@@ -45,7 +45,7 @@ class pServerBlock {
 		void add_server_name(string server_name);
 		void add_error_page(int code, string page);
 		void set_error_pages(map<int, string> error_pages);
-		void set_client_max_body_size(string client_max_body_size);
+		void set_client_max_body_size(unsigned int client_max_body_size);
 		void set_root(string root);
 		void set_index(string index);
 		void set_locations(vector<Location> locations);

--- a/include/stuff.hpp
+++ b/include/stuff.hpp
@@ -38,6 +38,7 @@
 #include <signal.h>
 #include <sys/wait.h>
 #include <filesystem>
+#include <type_traits>
 
 using namespace std;
 
@@ -61,4 +62,31 @@ void color_print(string color, Args... args) {
 	cout << color;
 	(cout << ... << args);
 	cout << RESET << endl;
+}
+
+template<typename T>
+string formatNumberPrint(T value) {
+    static_assert(is_integral<T>::value, "Type must be an integral type.");
+    
+    // Convert the number to a string
+    ostringstream oss;
+    oss << value;
+    string number = oss.str();
+
+    // Format the integer part with thousands separators
+    string formattedIntegerPart;
+    int count = 0;
+
+    for (int i = number.length() - 1; i >= 0; --i) {
+        if (count > 0 && count % 3 == 0) {
+            formattedIntegerPart += '.'; // Add the thousands separator (dot)
+        }
+        formattedIntegerPart += number[i];
+        count++;
+    }
+
+    // Reverse the formatted integer part to restore original order
+    reverse(formattedIntegerPart.begin(), formattedIntegerPart.end());
+
+    return formattedIntegerPart; // Return formatted number
 }

--- a/src/parsing/ParseServerBlock.cpp
+++ b/src/parsing/ParseServerBlock.cpp
@@ -6,7 +6,7 @@ pServerBlock::pServerBlock()
 	_listen = "";
 	_host = "";
 	_port = 0;
-	_client_max_body_size = "";
+	_client_max_body_size = 0;
 	_root = "";
 	_index = "";
 }
@@ -16,7 +16,7 @@ pServerBlock::pServerBlock(string listen,
 	int port,
 	string root,
 	string index,
-	string client_max_body_size,
+	unsigned int client_max_body_size,
 	vector<string> server_names,
 	map<int, string> error_pages,
 	vector<Location> locations)
@@ -39,7 +39,7 @@ string pServerBlock::get_host() const { return _host; }
 int pServerBlock::get_port() const { return _port; }
 string pServerBlock::get_root() const { return _root; }
 string pServerBlock::get_index() const { return _index; }
-string pServerBlock::get_client_max_body_size() const { return _client_max_body_size; }
+unsigned int pServerBlock::get_client_max_body_size() const { return _client_max_body_size; }
 vector<string> pServerBlock::get_server_names() const { return _server_names; }
 vector<Location> pServerBlock::get_locations() const { return _locations; }
 map<int, string> pServerBlock::get_error_pages() const { return _error_pages; }
@@ -49,7 +49,7 @@ void pServerBlock::set_host(string host) { _host = host; }
 void pServerBlock::set_port(int port) { _port = port; }
 void pServerBlock::set_root(string root) { _root = root; }
 void pServerBlock::set_index(string index) { _index = index; }
-void pServerBlock::set_client_max_body_size(string client_max_body_size) { _client_max_body_size = client_max_body_size; }
+void pServerBlock::set_client_max_body_size(unsigned int client_max_body_size) { _client_max_body_size = client_max_body_size; }
 void pServerBlock::set_server_names(vector<string> server_name) { _server_names = server_name; }
 void pServerBlock::add_server_name(string server_name) { _server_names.push_back(server_name); }
 void pServerBlock::add_error_page(int code, string page) { _error_pages[code] = page; }
@@ -72,7 +72,7 @@ void pServerBlock::print_server_block() {
 		cout << it->first << " " << it->second << endl;
 	}
 
-	cout << "Client max body size: " << (_client_max_body_size.empty() ? is_not_set() : _client_max_body_size) << endl;
+	cout << "Client max body size: " << _client_max_body_size << endl;
 	cout << "Root: " << (_root.empty() ? is_not_set() : _root) << endl;
 	cout << "Index: " << (_index.empty() ? is_not_set() : _index) << endl;
 	for (int i = 0; i < _locations.size(); i++) {

--- a/src/parsing/directive_handlers.cpp
+++ b/src/parsing/directive_handlers.cpp
@@ -140,11 +140,11 @@ void s_client_max_body_size(vector<string> &s, pServerBlock &block) {
 	// check if the string is in the allowed set
 	for (size_t i = 0; i < str.length(); i++) {
 		if (allowedSet.find(str[i]) == string::npos)
-			throw invalid_argument("client_max_body_size: non allowed character: " + str[i]);
+			throw invalid_argument("client_max_body_size: non allowed character: " + string(1, str[i]));
 	}
 
 	// check the count of letters
-	int nonDigitCount = count_if(input.begin(), input.end(), [](char ch) {
+	int nonDigitCount = count_if(str.begin(), str.end(), [](char ch) {
         return !isdigit(static_cast<unsigned char>(ch));
     });
 	if (nonDigitCount > 1) {
@@ -155,22 +155,22 @@ void s_client_max_body_size(vector<string> &s, pServerBlock &block) {
 	if (nonDigitCount == 1) {
 		char lastChar = str[str.length() - 1];
 		if (validEnds.find(lastChar) == string::npos) {
-			throw invalid_argument("client_max_body_size: invalid last character: " + lastChar);
+			throw invalid_argument("client_max_body_size: invalid last character: " + string(1, lastChar));
 		}
 		tempBodySize = stoll(str.substr(0, str.length() - 1));
 		if (lastChar == 'k' || lastChar == 'K') {
 			if (str.length() > 8) {
-				throw invalid_argument("client_max_body_size: out of range number: " + tempBodySize);
+				throw invalid_argument("client_max_body_size: out of range number: " + str);
 			}
 			tempBodySize *= oneKiloByte;
 		} else if (lastChar == 'm' || lastChar == 'M') {
 			if (str.length() > 5) {
-				throw invalid_argument("client_max_body_size: out of range number: " + tempBodySize);
+				throw invalid_argument("client_max_body_size: out of range number: " + str);
 			}
 			tempBodySize *= oneMegaByte;
 		} else if (lastChar == 'g' || lastChar == 'G') {
 			if (str.length() > 2) {
-				throw invalid_argument("client_max_body_size: out of range number: " + tempBodySize);
+				throw invalid_argument("client_max_body_size: out of range number: " + str);
 			}
 			tempBodySize *= oneGigaByte;
 		}
@@ -178,12 +178,13 @@ void s_client_max_body_size(vector<string> &s, pServerBlock &block) {
 		tempBodySize = stoll(str);
 	}
 	if (tempBodySize < 0 || tempBodySize > oneGigaByte) {
-		throw invalid_argument("client_max_body_size: out of range number: " + tempBodySize);
+		throw invalid_argument("client_max_body_size: out of range number: " + formatNumberPrint(tempBodySize));
 	}
 	unsigned int bodySize = static_cast<unsigned int>(tempBodySize);
 	if (bodySize == 0) {
-		throw invalid_argument("client_max_body_size: invalid number: " + tempBodySize);
+		throw invalid_argument("client_max_body_size: invalid number: " + formatNumberPrint(tempBodySize));
 	}
+	cout << "PARSER: CLIENT_MAX_BODY_SIZE: " << formatNumberPrint(bodySize) << endl;
 	block.set_client_max_body_size(bodySize);
 }
 


### PR DESCRIPTION
client_max_body_size is now an unsigned int.
There is a cap of 1gigabyte.
Works with the expected kK,mM, gG suffix.
Error checks everything else.

Also added a thousand divider print function for readabilty.

If client_max_body_size == 0, that means its unset and should be ignored.
